### PR TITLE
DB上で仮想マシンが扱えるようにする

### DIFF
--- a/vm/forms.py
+++ b/vm/forms.py
@@ -1,0 +1,16 @@
+from django import forms
+from .models import VirtualMachine
+
+class CreateVM(forms.Form):
+  name = forms.CharField()
+  memorysize = forms.ChoiceField(initial="1", choices = [(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)])
+  cpu = forms.ChoiceField(initial="1", choices = [(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)])
+  os = forms.ChoiceField(choices = [("FreeBSD10.1", "FreeBSD10.1"), ("Ubuntu14.04", "Ubuntu14.04"), ("Ubuntu12.04", "Ubuntu12.04"), ("Arch", "Arch"), ("debian8.0", "debian8.0")])
+  disksize = forms.IntegerField(initial="1024")
+  password = forms.CharField(initial="hoge")
+  vncport = forms.CharField(initial="5777")
+
+  def create_instance(self, user):
+    attributes = self.cleaned_data
+    attributes['user'] = user
+    return VirtualMachine(attributes=attributes)

--- a/vm/migrations/0004_virtualmachinerecord.py
+++ b/vm/migrations/0004_virtualmachinerecord.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('vm', '0003_auto_20150610_0309'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='VirtualMachineRecord',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(default=b'your virtual machine', max_length=100)),
+                ('uuid', models.CharField(max_length=100)),
+                ('vncport', models.CharField(max_length=100)),
+                ('password', models.CharField(max_length=100)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/vm/models.py
+++ b/vm/models.py
@@ -1,9 +1,78 @@
-from django import forms
+from django.db import models
+from django.contrib.auth.models import User
+from django.forms.models import model_to_dict
+from .vmoperation import VMCreateOperation, VMSearchQuery
 
-class CreateVM(forms.Form):
-  name = forms.CharField()
-  memorysize = forms.ChoiceField(initial="1", choices = [(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)])
-  cpu = forms.ChoiceField(initial="1", choices = [(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)])
-  os = forms.ChoiceField(choices = [("FreeBSD10.1", "FreeBSD10.1"), ("Ubuntu14.04", "Ubuntu14.04"), ("Ubuntu12.04", "Ubuntu12.04"), ("Arch", "Arch"), ("debian8.0", "debian8.0")])
-  disksize = forms.IntegerField(initial="1024")
+class VirtualMachine():
+  """
+  Having full information about a virtual machine
+  from the database and the hypervisor.
+  """
+  @classmethod
+  def from_record(cls, record):
+    res = VMSearchQuery(record.uuid).search()
+    return cls(instance=record, attributes=res)
 
+  def __init__(self, instance=None, attributes={}):
+    self.instance = instance
+    if not instance is None:
+      attrs = {}
+      attrs.update(model_to_dict(instance))
+      attrs.update(attributes)
+      attributes = attrs
+    self.attributes = attributes
+    self._set_attrs()
+
+  def _set_attrs(self):
+    keys = ['name', 'uuid', 'vncport', 'password', 'state', 'memorysize', 'os', 'password', 'vncport']
+    for key in keys:
+      if self.attributes.has_key(key):
+        self.__dict__[key] = self.attributes[key]
+
+  def to_record(self):
+    if self.instance is None:
+      self.instance = VirtualMachineRecord.from_virtual_machine(self)
+    return self.instance
+
+  def save(self):
+    if self.is_new():
+      self.attributes['uuid'] = VMCreateOperation(self).submit().get_uuid()
+    else:
+      # TODO: Update attributes
+      pass
+    self.to_record().save()
+    return self
+
+  def is_new(self):
+    return not self.attributes.has_key('uuid')
+
+  def get_uuid(self):
+    return self.attributes.get('uuid')
+
+  def get_user(self):
+    return self.attributes.get('user')
+
+  def get_values(self, keys=None):
+    if keys is None:
+      keys = self.attributes.keys()
+    values = {}
+    for key in keys:
+      values[key] = self.attributes[key]
+    return values
+
+class VirtualMachineRecord(models.Model):
+  """ A record class whose instance is saved in the database. """
+  user = models.ForeignKey(User)
+  name = models.CharField(max_length=100, default='your virtual machine')
+  uuid = models.CharField(max_length=100)
+  vncport = models.CharField(max_length=100)
+  password = models.CharField(max_length=100)
+
+  @classmethod
+  def from_virtual_machine(cls, vm):
+    user = vm.get_user()
+    attrs = vm.get_values(['name', 'uuid', 'vncport', 'password'])
+    return cls.objects.create(user=user, **attrs)
+
+  def __unicode__(self):
+    return self.name

--- a/vm/templates/vm/index.html
+++ b/vm/templates/vm/index.html
@@ -1,7 +1,7 @@
-{% if vmnames %}
+{% if vms %}
 <ul>
-{% for vmname in vmnames %}
-<li><a href="{% url 'noVNC:index'%}?host=157.82.3.111&port=5777&password=hoge">{{ vmname }}</a></li>
+{% for vm in vms %}
+<li><a href="{% url 'noVNC:index'%}?host=157.82.3.111&port=5777&password=hoge">{{ vm.name }}</a>: {{ vm.state }}</li>
 {% endfor %}
 </ul>
 {% else %}

--- a/vm/views.py
+++ b/vm/views.py
@@ -2,16 +2,10 @@ from django.shortcuts import render, render_to_response
 from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from django.template import Context, loader, RequestContext
-
-from .models import CreateVM
-
 from django.template.context_processors import csrf
 
 from vmoperation import VMOperator
-
-import uuid
-from . import tool
-
+from .forms import CreateVM
 
 @login_required
 def index(request):
@@ -27,33 +21,16 @@ def index(request):
   context = Context({'vmnames': vmnames })
   return HttpResponse(template.render(context))
 
-
 @login_required
 def create_vm(request):
-  op = VMOperator()
   if(request.method == 'POST'):
     f = CreateVM(request.POST)
-    if(f.is_valid()):
-      name = f.cleaned_data['name']
-      memory = f.cleaned_data['memorysize']
-      cpu = f.cleaned_data['cpu']
-      os = f.cleaned_data['os']
-      disksize  = f.cleaned_data['disksize']
-      print name
-      print memory
-      print cpu
-      print os
-      print disksize
-      macaddr = tool.GenMac()
-      uuid_gen = uuid.uuid4()
-      websocketport = "5777"
-      passwd = "hoge"
-      xml = tool.XMLGen(name, uuid_gen, memory, cpu, os, macaddr, websocketport, passwd)
-      op.create_vm(xml)
+    if (f.is_valid()):
+      f.create_instance(request.user).save()
       return HttpResponseRedirect('vm/success')
   else:
     f = CreateVM()
-    return render_to_response('vm/create_vm.html', {'form': f},context_instance=RequestContext(request))
+    return render_to_response('vm/create_vm.html', {'form': f}, context_instance=RequestContext(request))
 
 @login_required
 def success(request):

--- a/vm/views.py
+++ b/vm/views.py
@@ -6,20 +6,13 @@ from django.template.context_processors import csrf
 
 from vmoperation import VMOperator
 from .forms import CreateVM
+from .models import VirtualMachine
 
 @login_required
 def index(request):
-  template = loader.get_template('vm/index.html')
-  op = VMOperator()
-  vms = op.get_vm_names_state()
-  print "vms"
-  print vms
-  vmnames = []
-  for vm in vms:
-    vmnames.append(vm.name())
-  print vmnames
-  context = Context({'vmnames': vmnames })
-  return HttpResponse(template.render(context))
+  vm_records = request.user.virtualmachinerecord_set.all()
+  vms = [VirtualMachine.from_record(vm) for vm in vm_records]
+  return render(request, 'vm/index.html', {'vms': vms})
 
 @login_required
 def create_vm(request):

--- a/vm/vmoperation/__init__.py
+++ b/vm/vmoperation/__init__.py
@@ -3,3 +3,48 @@ if settings.PRODUCTION:
     from .production import *
 else:
     from .dev import *
+
+from .. import tool
+import uuid
+
+class VMCreateOperation():
+  @classmethod
+  def get_operator(cls):
+    if not hasattr(cls, 'operator'):
+      cls.operator = VMOperator()
+    return cls.operator
+
+  def __init__(self, vm):
+    self.vm = vm
+
+  def submit(self):
+    data = self.vm.get_values()
+    xml = tool.XMLGen(
+      data['name'], self.get_uuid(), data['memorysize'], data['cpu'], data['os'],
+      self.get_macaddr(), data['vncport'], data['password'])
+    self.__class__.get_operator().create_vm(xml)
+    return self
+
+  def get_uuid(self):
+    if not hasattr(self, 'uuid'):
+      self.uuid = uuid.uuid4()
+    return self.uuid
+
+  def get_macaddr(self):
+    if not hasattr(self, 'macaddr'):
+      self.macaddr = tool.GenMac()
+    return self.macaddr
+
+class VMSearchQuery():
+  @classmethod
+  def get_operator(cls):
+    if not hasattr(cls, 'operator'):
+      cls.operator = VMOperator()
+    return cls.operator
+
+  def __init__(self, uuid):
+    self.uuid = uuid
+
+  def search(self):
+    attrs = self.__class__.get_operator().get_vminfo(self.uuid)
+    return attrs

--- a/vm/vmoperation/dev.py
+++ b/vm/vmoperation/dev.py
@@ -1,3 +1,5 @@
 
 class VMOperator():
-    pass
+  def create_vm(self, xml):
+    print 'vm_created: '
+    print xml

--- a/vm/vmoperation/dev.py
+++ b/vm/vmoperation/dev.py
@@ -3,3 +3,6 @@ class VMOperator():
   def create_vm(self, xml):
     print 'vm_created: '
     print xml
+
+  def get_vminfo(self, uuid) :
+    return {"name": uuid, "state": 'Stop', "memorysize": '4000'}

--- a/vm/vmoperation/production.py
+++ b/vm/vmoperation/production.py
@@ -9,9 +9,9 @@
 
 # Notice: In this library UUID is used as vm handle.
 
-from uuid import UUID
 import os
 import libvirt
+from uuid import UUID
 
 class VMOperator():
   hypervisor_url = "qemu+tls://157.82.3.111/system"
@@ -19,15 +19,6 @@ class VMOperator():
     self.con = libvirt.open(self.hypervisor_url)
     if self.con is None:
       raise
-
- # def __init__(self, hypervisor_uri):
- #   if hypervisor_uri is None:
- #     raise
- #   self.uri = hypervisor_uri
-
- #   self.con = libvirt.open(self.uri)
- #   if self.con is None:
- #     raise
 
   def start(self, uuid) :
     os.system("virsh -c {:s} start {:s}".format(self.hypervisor_url, str(uuid)))
@@ -68,7 +59,7 @@ class VMOperator():
 
     infos = vm.info()
 
-    return {"same":vm.name(), "state": infos[0], "memory": infos[1]}
+    return {"name":vm.name(), "state": infos[0], "memory": infos[1]}
 
   def get_vmlist(self) :
     vms_uuid = []
@@ -103,9 +94,6 @@ class VMOperator():
       uuid = UUID(bytes=self.con.lookupByName(vmname).UUID())
       vms.append(self.con.lookupByUUID(uuid.bytes))
     return vms
-
-
-
 
 if __name__ == '__main__':
   op = VMOperator()

--- a/vm/vmoperation/production.py
+++ b/vm/vmoperation/production.py
@@ -59,7 +59,7 @@ class VMOperator():
 
     infos = vm.info()
 
-    return {"name":vm.name(), "state": infos[0], "memory": infos[1]}
+    return {"name":vm.name(), "state": infos[0], "memorysize": infos[1]}
 
   def get_vmlist(self) :
     vms_uuid = []


### PR DESCRIPTION
vmアプリ上で、`create_vm`でデータベースにvmを保存するようにして、`index`でユーザーに紐付けられたvmの情報だけ表示するようにしました。
## 実装

VirtualMachine, VirtualMachineRecordというクラスを追加しました。

VirtualMachineRecordはデータベースに保存する情報だけ扱います。

VirtualMachineは`os`とか`state`とか`memorysize`とかdatabaseに保存しない情報も扱います。
`VirtualMachine#save`メソッドで、データベースとハイパーバイザーにvmの作成をして、
`VirtualMachine.from_record`メソッドで、データベースにあるuuidを使ってハイパーバイザーからvmの情報を読み込みます。

割と急ぎで作ったのでなんかわからないところがあったら聞いてください… :bow: 
(本番環境で試してないので試せるなら試して欲しい :pray: )
https://edu.jar.jp/redmine/issues/426
