### PR TITLE
VirtualMachineとvmoperationのリファクタリング

### DIFF
--- a/vm/models.py
+++ b/vm/models.py
@@ -74,7 +74,13 @@ class VirtualMachine(object):
   def is_new(self):
     return self.uuid is None
 
+  def get_disksize_byte(self):
+    # a unit of disksize is giga byte.
+    return 1024 * 1024 * 1024 * self.disksize
 
+  def get_memorysize_kilobyte(self):
+    # a unit of disksize is giga byte.
+    return 1024 * 1024 * self.memorysize
 
 class VirtualMachineRecord(models.Model):
   """ A record class whose instance is saved in the database. """

--- a/vm/views.py
+++ b/vm/views.py
@@ -23,6 +23,7 @@ def create_vm(request):
   if(request.method == 'POST'):
     f = CreateVM(request.POST)
     if (f.is_valid()):
+      # TODO: move these default values to models
       vncport = VirtualMachineRecord.find_vnc_port()
       passwd = random_str = ''.join([random.choice(string.ascii_letters + string.digits) for i in range(10)])
       f.create_instance(request.user, vncport, passwd).save()

--- a/vm/vmoperation/__init__.py
+++ b/vm/vmoperation/__init__.py
@@ -7,19 +7,20 @@ else:
 from .. import tool
 import uuid
 
-class VMCreateOperation():
+class VMOperationBase():
   @classmethod
   def get_operator(cls):
     if not hasattr(cls, 'operator'):
       cls.operator = VMOperator()
     return cls.operator
 
+class VMCreateOperation(VMOperationBase):
   def __init__(self, vm):
     self.vm = vm
 
   def submit(self):
     data = self.vm.get_values()
-    
+
     storagexml=tool.StorageXMLGen(data['name'], 1024*1024*1024*data['disksize'])
     print storagexml
     self.__class__.get_operator().create_storage(storagexml)
@@ -41,13 +42,15 @@ class VMCreateOperation():
       self.macaddr = tool.GenMac()
     return self.macaddr
 
-class VMSearchQuery():
-  @classmethod
-  def get_operator(cls):
-    if not hasattr(cls, 'operator'):
-      cls.operator = VMOperator()
-    return cls.operator
+class VMUpdateOperation(VMOperationBase):
+  def __init__(self, vm):
+    self.vm = vm
 
+  def submit():
+    # TODO
+    pass
+
+class VMSearchQuery(VMOperationBase):
   def __init__(self, uuid):
     self.uuid = uuid
 

--- a/vm/vmoperation/__init__.py
+++ b/vm/vmoperation/__init__.py
@@ -19,28 +19,43 @@ class VMCreateOperation(VMOperationBase):
     self.vm = vm
 
   def submit(self):
-    data = self.vm.get_values()
-
-    storagexml=tool.StorageXMLGen(data['name'], 1024*1024*1024*data['disksize'])
-    print storagexml
-    self.__class__.get_operator().create_storage(storagexml)
-    vmxml = tool.VMXMLGen(
-      data['name'], self.get_uuid(), 1024*1024*int(data['memorysize']), data['cpu'], data['os'],
-      self.get_macaddr(), data['vncport'], data['password'])
-    print vmxml
-    self.__class__.get_operator().define_vm(vmxml)
-    self.__class__.get_operator().start_vm(data['name'])
+    self._define_storage()
+    self._define_vm()
+    self._start()
     return self
 
+  # TODO: move this method to models
   def get_uuid(self):
     if not hasattr(self, 'uuid'):
       self.uuid = uuid.uuid4()
     return self.uuid
 
+  # TODO: move this method to models
   def get_macaddr(self):
     if not hasattr(self, 'macaddr'):
       self.macaddr = tool.GenMac()
     return self.macaddr
+
+  def _define_storage(self):
+    storagexml = tool.StorageXMLGen(self.vm.name, self.vm.get_disksize_byte())
+    print storagexml
+    self.__class__.get_operator().create_storage(storagexml)
+
+  def _define_vm(self):
+    vmxml = tool.VMXMLGen(
+      hostname = self.vm.name,
+      uuid = self.get_uuid(),
+      memorysize = self.vm.get_memorysize_kilobyte(),
+      cpu = self.vm.cpu,
+      image_file = self.vm.os,
+      macaddr = self.get_macaddr(),
+      websocketport = self.vm.vncport,
+      passwd = self.vm.password)
+    print vmxml
+    self.__class__.get_operator().define_vm(vmxml)
+
+  def _start(self):
+    self.__class__.get_operator().start_by_hostname(self.vm.name)
 
 class VMUpdateOperation(VMOperationBase):
   def __init__(self, vm):

--- a/vm/vmoperation/dev.py
+++ b/vm/vmoperation/dev.py
@@ -6,3 +6,15 @@ class VMOperator():
 
   def get_vminfo(self, uuid) :
     return {"name": uuid, "state": 'Stop', "memorysize": '4000'}
+
+  def create_storage(self, xml):
+    print 'storage_created: '
+    print xml
+
+  def define_vm(self, xml):
+    print 'define_vm: '
+    print xml
+
+  def start_by_hostname(self, hostname):
+    print 'vm_: '
+    print hostname

--- a/vm/vmoperation/production.py
+++ b/vm/vmoperation/production.py
@@ -52,8 +52,8 @@ class VMOperator():
 
   def define_vm(self, xml) :
     self.con.defineXML(xml)
-  
-  def start_vm(self, hostname) :
+
+  def start_by_hostname(self, hostname) :
     self.con.lookupByName(hostname).create()
 
   def destroy_vm(self) :


### PR DESCRIPTION
VMの編集機能つけようと思ってたけど忙しくて中々作れてないので、とりあえず先にソースコードの整理したのだけmasterに取り入れたいです :bow: レビューください
# 変更点
- `vmoperation` の関数とかの整理をした
- `VirtualMachine` クラスのリファクタリング(後述)
## `VirtualMachine` クラスのリファクタリング

このまま編集可能にしようとすると問題があると思ったのであちこちリファクタリングしました。
### `VirtualMachineRecord`と`VirtualMachine`の一部の属性をリンクさせるようにした

`name`とか`uuid`とかのデータベースに保存するような属性について、 `VirtualMachineRecord` と `VirtualMachine` が別々にデータ持っていたのですが、
これをプロパティ使って同じデータを持つようにしました。

例えば、`VirtualMachine`の`name`と`VirtualMachineRecord`の`name`が常におなじになるようになっています。
### データベースに保存しない属性の扱い

いままで`attributes`に突っ込んでいたのですが、それだと`VirtualMachine`が何の属性持っているか管理しきれなくなるので、djangoのModelっぽい感じで型含めて`attribute`という関数で宣言して管理するようにしました。

実験的な機能なのですが、`attribute`に型変換の関数(`int`とか`unicode`とか)を渡すと、代入時にその型に変換されます。(disksizeに文字列を代入しようとしても、Intに変換されて代入される)

フォームの入力とかlibvirtから得られる情報とか、Int欲しいのに文字列で渡されることがあるみたいなのですが、管理がめんどくさいのでこれでうまくいけばいいなーと思っています。
