### PR TITLE
noVNCパラメータをnoVNCページに埋め込む

### DIFF
--- a/noVNC/templates/noVNC/vnc_auto.html
+++ b/noVNC/templates/noVNC/vnc_auto.html
@@ -29,6 +29,13 @@
 {% endblock %}
 
 {% block additional_body %}
+<script id="novnc-parameter" type="application/json">
+{
+  "host": "{{ novnc_url }}",
+  "port": "{{ vm.vncport }}",
+  "password": "{{ vm.password }}"
+}
+</script>
 <script>
   var INCLUDE_URI="{% static "noVNC/include/" %}";
 </script>

--- a/noVNC/urls.py
+++ b/noVNC/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    url(r'^(?P<vm_id>[0-9]+)$', views.index, name='index'),
 ]

--- a/noVNC/views.py
+++ b/noVNC/views.py
@@ -1,12 +1,16 @@
 from django.shortcuts import render
 
 # Create your views here.
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.template import Context, loader
 
+from vm.models import VirtualMachine, VirtualMachineRecord
+from django.conf import settings
+
 @login_required
-def index(request):
-  template = loader.get_template('noVNC/vnc_auto.html')
-  return HttpResponse(template.render())
+def index(request, vm_id):
+  vm_record = get_object_or_404(VirtualMachineRecord, pk=vm_id)
+  vm = VirtualMachine.from_record(vm_record)
+  return render(request, 'noVNC/vnc_auto.html', { 'vm': vm, 'novnc_url': settings.HYPERVISOR_URL })

--- a/vm/templates/vm/index.html
+++ b/vm/templates/vm/index.html
@@ -225,7 +225,7 @@ $(function () { StartTimer(); });
   {% for vm in vms %}
   <tr>
     <td><center>{{vm.name}}</center></td>
-    <td><a href="{% url 'noVNC:index'%}?host={{HYPERVISOR_URL}}&port={{vm.vncport}}&password={{vm.password}}"  ><center><img src="{% static "vm/png/glyphicons-87-display.png" %}" class="img-responsive" alt="Responsive image"/></center></a></td>
+    <td><a href="{% url 'noVNC:index' vm_id=vm.id %}?host={{HYPERVISOR_URL}}&port={{vm.vncport}}&password={{vm.password}}"  ><center><img src="{% static "vm/png/glyphicons-87-display.png" %}" class="img-responsive" alt="Responsive image"/></center></a></td>
     <td> {{ vm.state }}</td>
     <td data-cpuusage="{% for cpu in cpus %}{% if forloop.last %}{{vm.uuid}}.{{forloop.counter}}.txt"{% else %}{{vm.uuid}}.{{forloop.counter}}.txt,{% endif %}{% endfor %}/>
     <td><a href="{% url 'vm:edit' vm_id=vm.id %}">Edit</a></td>


### PR DESCRIPTION
#14 #15 に依存しています。

ページにnoVNCで使うパラメータを埋め込むようにしました。(host, password, port)
`$.parseJSON($('#novnc-parameter').html())`でパース出来ます。

redmine: https://edu.jar.jp/redmine/issues/542
