### PR TITLE
IP直打ちをやめる

### DIFF
--- a/ews/settings/dev.py.local
+++ b/ews/settings/dev.py.local
@@ -17,3 +17,6 @@ SECRET_KEY = 'please-set-very-long-words'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 PRODUCTION = False
+
+# Rewrite this url to the hypervisor's url.
+HYPERVISOR_URL = '127.0.0.1'

--- a/ews/settings/production.py.local
+++ b/ews/settings/production.py.local
@@ -16,3 +16,5 @@ SECRET_KEY = 'please-set-very-long-words'
 
 DEBUG = False
 PRODUCTION = True
+
+HYPERVISOR_URL = 127.0.0.1

--- a/vm/templates/vm/index.html
+++ b/vm/templates/vm/index.html
@@ -6,7 +6,7 @@
 {% if vms %}
 <ul>
 {% for vm in vms %}
-<li><a href="{% url 'noVNC:index'%}?host=157.82.3.111&port={{vm.vncport}}&password={{vm.password}}"  >{{ vm.name }}</a>: {{ vm.state }}</li>
+<li><a href="{% url 'noVNC:index'%}?host={{HYPERVISOR_URL}}&port={{vm.vncport}}&password={{vm.password}}"  >{{ vm.name }}</a>: {{ vm.state }}</li>
 {% endfor %}
 </ul>
 {% else %}

--- a/vm/views.py
+++ b/vm/views.py
@@ -8,6 +8,8 @@ from vmoperation import VMOperator
 from .forms import CreateVM
 from .models import VirtualMachine, VirtualMachineRecord
 
+from django.conf import settings
+
 import uuid
 import string
 import random
@@ -16,7 +18,7 @@ import random
 def index(request):
   vm_records = request.user.virtualmachinerecord_set.all()
   vms = [VirtualMachine.from_record(vm) for vm in vm_records]
-  return render(request, 'vm/index.html', {'vms': vms})
+  return render(request, 'vm/index.html', {'vms': vms, 'HYPERVISOR_URL': settings.HYPERVISOR_URL})
 
 @login_required
 def create_vm(request):

--- a/vm/vmoperation/production.py
+++ b/vm/vmoperation/production.py
@@ -12,9 +12,10 @@
 import os
 import libvirt
 from uuid import UUID
+from django.conf import settings
 
 class VMOperator():
-  hypervisor_url = "qemu+tls://157.82.3.111/system"
+  hypervisor_url = "qemu+tls://" + settings.HYPERVISOR_URL + "/system"
   def __init__(self):
     self.con = libvirt.open(self.hypervisor_url)
     if self.con is None:


### PR DESCRIPTION
ハイパーバイザーのIP直打ちをやめる :no_good:

`ews/settings/{dev, production}.py.local`に変更を加えてるのでmerge後は
`HYPERVISOR_URL = "(ハイパーバイザーのurl)"`というように変更を加えてください。

redmine: https://edu.jar.jp/redmine/issues/514
