### PR TITLE
インデント幅をTravis CIでチェックするようにする

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
-python: "2.7"
-install: "pip install -r requirements.txt"
-script: "pylint *"
+python: '2.7'
+install: pip install -r requirements.txt
+script: pylint *
+notifications:
+  slack:
+    secure: qBrtbEbOdEH9FHWXhVPZJtW9G+o2kfwLPfLKRQjnE7FPnfRRRT1YzYuJ6bUaKbUOrAs063M45N2CU+aScWNqJ9dnCZBCC3xlbUjLQV5mCUyfR89QP4pCL/8d8fBci8rUCpv+QZI9UlKJorLnwm6KL7T0KocvHMb//gPSfewl8eGGbNoL5NDX+licxdbR91FVCCvLDGl/zUhh6yd1CABFbCHJZ48n5MrowXGxGM8MKjWdIyZLMQnb0+dRswv6J0KzYGqFS9uvIPpWoq2nJVKyD52nLtY/hN1Yq1H4GfTF8lluh90Jd5FR1K+SZqi3RkWYTZjhMEfCOnuAlePXCYsNtJDrJmWTQvzglccjwpRwxOb2uQSBlZl5RXcKIorqW9mWexWC1PVQqmnEe5drtstcZpVlFBFjJGZs4NYOA4h96urEGxhlB8e2cr923m+j0Tjo1gFYeOAHj3BLlb68Se6VAZ/AM8WoSBjNPggZChkNmwB0ypOMkU/nFGcXk6MS8C/4SmmWEHT31nibBAjbnR7brp7JKfkmcA9NwhqU8rqhsFfrzQLVLoh5BWGPHCBrUy3OHHXity1uEYYmAAviSdQR7aS2138HcfZmOfDTMLaUf7z35nFjKQcEIANBwIobMuH83L2dtNl8xwjicC8oR2yjAuD02FUK+kJQclSIz6nlQ/g=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python: "2.7"
+install: "pip install -r requirements.txt"
+script: "pylint *"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ews
+# ews [![Build Status](https://travis-ci.org/tomoasleep/ews.svg)](https://travis-ci.org/tomoasleep/ews)
 Enpit Web Service(仮)
 
 # 機能

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,3 +1,2 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-

--- a/noVNC/models.py
+++ b/noVNC/models.py
@@ -1,3 +1,2 @@
 from django.db import models
 from django.contrib.auth.models import User
-

--- a/noVNC/views.py
+++ b/noVNC/views.py
@@ -11,6 +11,6 @@ from django.conf import settings
 
 @login_required
 def index(request, vm_id):
-  vm_record = get_object_or_404(VirtualMachineRecord, pk=vm_id)
-  vm = VirtualMachine.from_record(vm_record)
-  return render(request, 'noVNC/vnc_auto.html', { 'vm': vm, 'novnc_url': settings.HYPERVISOR_URL })
+    vm_record = get_object_or_404(VirtualMachineRecord, pk=vm_id)
+    vm = VirtualMachine.from_record(vm_record)
+    return render(request, 'noVNC/vnc_auto.html', { 'vm': vm, 'novnc_url': settings.HYPERVISOR_URL })

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,27 @@
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=W0311,W0312
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django >=1.8
+pylint >=1.4

--- a/statistics/stat.py
+++ b/statistics/stat.py
@@ -10,10 +10,10 @@ cpurrdpath = statpath + "cpu/"
 cpuusagepath = statpath + "cpuusage/"
 
 def rrd2plain():
-  print "write to cpuuusage"
-  files = os.listdir(cpurrdpath)
-  for file in files:
-    os.system('rrdtool fetch '+ cpurrdpath + file + ' AVERAGE --start `date +%s`-600 |  sed -e \'1,3d\'  > ' +cpuusagepath + file.split('.')[0]+ "."+ file.split('.')[1]  +".txt" )
+    print "write to cpuuusage"
+    files = os.listdir(cpurrdpath)
+    for file in files:
+        os.system('rrdtool fetch '+ cpurrdpath + file + ' AVERAGE --start `date +%s`-600 |  sed -e \'1,3d\'  > ' +cpuusagepath + file.split('.')[0]+ "."+ file.split('.')[1]  +".txt" )
 
 
 def updateCpuRRD(uuid, idx, tm, util):
@@ -34,84 +34,84 @@ def updateCpuRRD(uuid, idx, tm, util):
     rrdtool.update(fname, dstr)
 
 
-  
+
 class StatCollector():
-  def __init__(self):
-    self.conn = libvirt.open(hypervisor_url)
-    self.UpdateVMlist()
-    self.cputimes = {}
-    self.lastupdatecpu = {}
+    def __init__(self):
+        self.conn = libvirt.open(hypervisor_url)
+        self.UpdateVMlist()
+        self.cputimes = {}
+        self.lastupdatecpu = {}
 
-  def isConnectionAlive(self):
-    try:
-      self.conn.getHostname()
-    except KeyboardInterrupt:
-      raise
-    except:
-      return False
-    return True
+    def isConnectionAlive(self):
+        try:
+            self.conn.getHostname()
+        except KeyboardInterrupt:
+            raise
+        except:
+            return False
+        return True
 
 
-  def UpdateVMlist(self):
-    self.vmlist = self.conn.listAllDomains()
-    
+    def UpdateVMlist(self):
+        self.vmlist = self.conn.listAllDomains()
 
-  def CollectStat(self):
-    self.UpdateVMlist()
-    for vm in self.vmlist:
-      curtime = time.time()
-      vminfo = vm.info()
-      uuid=vm.UUIDString()
-      name=vm.name()
-      id=vm.ID()
-      state= vminfo[0]
-      maxmem= vminfo[1]
-      mem= vminfo[2]
-      nvcpu= vminfo[3]
-      cputime= vminfo[4]
-      vcpus = {}
-      if vm.ID() < 0:
-         continue
 
-      tvcpus = vm.vcpus()
-      for i in range(nvcpu):
-        affinity = ""
-        for b in tvcpus[1][i]:
-          if b:
-            affinity += "y"
-          else:
-            affinity += "-"
-        vcpus[tvcpus[0][i][0]+1] = {"state":tvcpus[0][i][1],
-                                    "cputime":tvcpus[0][i][2],
-                                    "cpu" : tvcpus[0][i][3],
-                                    "affinity":affinity}
+    def CollectStat(self):
+        self.UpdateVMlist()
+        for vm in self.vmlist:
+            curtime = time.time()
+            vminfo = vm.info()
+            uuid=vm.UUIDString()
+            name=vm.name()
+            id=vm.ID()
+            state= vminfo[0]
+            maxmem= vminfo[1]
+            mem= vminfo[2]
+            nvcpu= vminfo[3]
+            cputime= vminfo[4]
+            vcpus = {}
+            if vm.ID() < 0:
+                continue
 
-      for cpuid in range(nvcpu):
-        cpuid += 1
-        cpukey = "%s.%d" % (uuid, cpuid)
-        if self.cputimes.has_key(cpukey):
-          difftime = curtime - self.lastupdatecpu[cpukey]
-          cptm = vcpus[cpuid]["cputime"] - self.cputimes[cpukey]
-          cpuutil = 1.0 * cptm /1000000000/difftime
-          print name
-          updateCpuRRD(uuid, cpuid, curtime, cpuutil)
-        self.cputimes[cpukey] = vcpus[cpuid]["cputime"]
-        self.lastupdatecpu[cpukey] = curtime
+            tvcpus = vm.vcpus()
+            for i in range(nvcpu):
+                affinity = ""
+                for b in tvcpus[1][i]:
+                    if b:
+                        affinity += "y"
+                    else:
+                        affinity += "-"
+                vcpus[tvcpus[0][i][0]+1] = {"state":tvcpus[0][i][1],
+                                            "cputime":tvcpus[0][i][2],
+                                            "cpu" : tvcpus[0][i][3],
+                                            "affinity":affinity}
+
+            for cpuid in range(nvcpu):
+                cpuid += 1
+                cpukey = "%s.%d" % (uuid, cpuid)
+                if self.cputimes.has_key(cpukey):
+                    difftime = curtime - self.lastupdatecpu[cpukey]
+                    cptm = vcpus[cpuid]["cputime"] - self.cputimes[cpukey]
+                    cpuutil = 1.0 * cptm /1000000000/difftime
+                    print name
+                    updateCpuRRD(uuid, cpuid, curtime, cpuutil)
+                self.cputimes[cpukey] = vcpus[cpuid]["cputime"]
+                self.lastupdatecpu[cpukey] = curtime
 
 
 if __name__ == "__main__":
-  stat = StatCollector()
-  i = 0
-  while True:
-    try:
-      stat.UpdateVMlist()
-      stat.CollectStat()
-      if i > 5:
-        rrd2plain()
-        i=0
-      time.sleep(1)
-      i+=1
-    except KeyboardInterrupt:
-      break
-    except Exception as e:
-      print "Exception ", e
+    stat = StatCollector()
+    i = 0
+    while True:
+        try:
+            stat.UpdateVMlist()
+            stat.CollectStat()
+            if i > 5:
+                rrd2plain()
+                i=0
+            time.sleep(1)
+            i+=1
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            print "Exception ", e

--- a/vm/admin.py
+++ b/vm/admin.py
@@ -3,8 +3,8 @@ from django.contrib import admin
 #jfrom .models import VirtualMachine
 
 class VMAdmin(admin.ModelAdmin):
-  fieldsets = [(None, { 'fields': ['name', 'uuid', 'user'] })]
-  list_display = ('uuid', 'user')
-  list_filter = ['user']
+    fieldsets = [(None, { 'fields': ['name', 'uuid', 'user'] })]
+    list_display = ('uuid', 'user')
+    list_filter = ['user']
 
 #admin.site.register(VirtualMachine, VMAdmin)

--- a/vm/forms.py
+++ b/vm/forms.py
@@ -7,59 +7,59 @@ cpu_field = forms.ChoiceField(initial="1", choices = [(1,1),(2,2),(3,3),(4,4),(5
 disksize_field = forms.IntegerField(initial="50")
 
 class CreateVM(forms.Form):
-  memorychoice = [(1,"1G"),(2,"2G"),(3,"3G"),(4,"4G"),(5,"5G"),(6,"6G"),(7,"7G"),(8,"8G")]
-  cpuchoice =[(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)]
-  oschoice = [
-  ('CentOS',(
-      ("CentOS-6.3-x86_64-minimal.iso", "CentOS-6.3-x86_64"),
-      ("CentOS-6.6-x86_64-minimal.iso", "CentOS-6.6-x86_64"),
-      )
-  ),
-  ('debian',(
-      ("debian-6.0.5-amd64-i386-netinst.iso", "debian-6.0.5-amd64"),
-      ("debian-8.0.0-amd64-netinst.iso", "debian-8.0.0-amd64"),
-      )
-  ),
-  ('FreeBSD', (
-      ("FreeBSD-8.2-RELEASE-amd64-bootonly.iso", "FreeBSD-8.2-RELEASE"),
-      ("FreeBSD-8.3-RELEASE-amd64-bootonly.iso", "FreeBSD-8.3-RELEASE"),
-      ("FreeBSD-9.3-RELEASE-amd64-disc1.iso", "FreeBSD-9.3-RELEASE"),
-      ("FreeBSD-10.1-RELEASE-amd64-bootonly.iso", "FreeBSD-10.1-RELEASE"),
-      )
-  ),
-  ('ubuntu', (
-      ("ubuntu-12.04-server-amd64.iso", "ubuntu-12.04-amd64"),
-      ("ubuntu-14.04.2-server-amd64.iso", "ubuntu-14.04.2-amd64"),
-      )
-  ),
-  ('other',(
-      ("archlinux-2015.06.01-dual.iso", "archlinux-2015.06.01"),
-      ("Gentoo-install-amd64-minimal-20120223.iso", "Gentoo-install-amd64-minimal-20120223"),
-      )
-  )
-  ]
+    memorychoice = [(1,"1G"),(2,"2G"),(3,"3G"),(4,"4G"),(5,"5G"),(6,"6G"),(7,"7G"),(8,"8G")]
+    cpuchoice =[(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8)]
+    oschoice = [
+    ('CentOS',(
+        ("CentOS-6.3-x86_64-minimal.iso", "CentOS-6.3-x86_64"),
+        ("CentOS-6.6-x86_64-minimal.iso", "CentOS-6.6-x86_64"),
+        )
+    ),
+    ('debian',(
+        ("debian-6.0.5-amd64-i386-netinst.iso", "debian-6.0.5-amd64"),
+        ("debian-8.0.0-amd64-netinst.iso", "debian-8.0.0-amd64"),
+        )
+    ),
+    ('FreeBSD', (
+        ("FreeBSD-8.2-RELEASE-amd64-bootonly.iso", "FreeBSD-8.2-RELEASE"),
+        ("FreeBSD-8.3-RELEASE-amd64-bootonly.iso", "FreeBSD-8.3-RELEASE"),
+        ("FreeBSD-9.3-RELEASE-amd64-disc1.iso", "FreeBSD-9.3-RELEASE"),
+        ("FreeBSD-10.1-RELEASE-amd64-bootonly.iso", "FreeBSD-10.1-RELEASE"),
+        )
+    ),
+    ('ubuntu', (
+        ("ubuntu-12.04-server-amd64.iso", "ubuntu-12.04-amd64"),
+        ("ubuntu-14.04.2-server-amd64.iso", "ubuntu-14.04.2-amd64"),
+        )
+    ),
+    ('other',(
+        ("archlinux-2015.06.01-dual.iso", "archlinux-2015.06.01"),
+        ("Gentoo-install-amd64-minimal-20120223.iso", "Gentoo-install-amd64-minimal-20120223"),
+        )
+    )
+    ]
 
-  name = forms.CharField(widget=forms.TextInput(attrs={'class' : 'form-control'}))
-  memorysize = forms.ChoiceField(initial="1", choices = memorychoice, widget=forms.Select(attrs={'class': 'selectpicker'}))
-  cpu = forms.ChoiceField(initial="1", choices = cpuchoice, widget=forms.Select(attrs={'class': 'selectpicker'}))
-  os = forms.ChoiceField(choices = oschoice, widget=forms.Select(attrs={'class': 'selectpicker', 'data-width':'auto'}))
-  disksize = forms.IntegerField(initial="50", widget=forms.NumberInput(attrs={'class' : 'form-control', 'data-width':'auto'}))
+    name = forms.CharField(widget=forms.TextInput(attrs={'class' : 'form-control'}))
+    memorysize = forms.ChoiceField(initial="1", choices = memorychoice, widget=forms.Select(attrs={'class': 'selectpicker'}))
+    cpu = forms.ChoiceField(initial="1", choices = cpuchoice, widget=forms.Select(attrs={'class': 'selectpicker'}))
+    os = forms.ChoiceField(choices = oschoice, widget=forms.Select(attrs={'class': 'selectpicker', 'data-width':'auto'}))
+    disksize = forms.IntegerField(initial="50", widget=forms.NumberInput(attrs={'class' : 'form-control', 'data-width':'auto'}))
 
-  def create_instance(self, user, vncport, passwd):
-    attributes = self.cleaned_data
-    attributes['user'] = user
-    attributes['vncport'] = vncport
-    attributes['password'] = passwd
-    return VirtualMachine(attributes=attributes)
+    def create_instance(self, user, vncport, passwd):
+        attributes = self.cleaned_data
+        attributes['user'] = user
+        attributes['vncport'] = vncport
+        attributes['password'] = passwd
+        return VirtualMachine(attributes=attributes)
 
 class UpdateVM(forms.Form):
-  memorysize = memory_field
-  cpu = cpu_field
-  disksize = disksize_field
+    memorysize = memory_field
+    cpu = cpu_field
+    disksize = disksize_field
 
-  @classmethod
-  def from_model(cls, vm):
-    return cls(initial={ 'memorysize': vm.memorysize, 'cpu': vm.cpu, 'disksize': vm.disksize })
+    @classmethod
+    def from_model(cls, vm):
+        return cls(initial={ 'memorysize': vm.memorysize, 'cpu': vm.cpu, 'disksize': vm.disksize })
 
-  def apply_update(self, vm):
-    return vm.update(self.cleaned_data)
+    def apply_update(self, vm):
+        return vm.update(self.cleaned_data)

--- a/vm/models.py
+++ b/vm/models.py
@@ -5,104 +5,104 @@ from .vmoperation import VMCreateOperation, VMSearchQuery, VMUpdateOperation
 import uuid
 
 def model_alias(name):
-  "Define an alias property to my instance"
-  def fget(self):
-    return getattr(self.instance, name)
-  def fset(self, val):
-    return setattr(self.instance, name, val)
-  return property(fget, fset)
+    "Define an alias property to my instance"
+    def fget(self):
+        return getattr(self.instance, name)
+    def fset(self, val):
+        return setattr(self.instance, name, val)
+    return property(fget, fset)
 
 def attribute(wrapper = (lambda x: x), doc = ''):
-  "Define a property always having the specified type"
-  class container():
-    value = None
-    def fget(cont, self):
-      return cont.value
-    def fset(cont, self, val):
-      if val is None:
-        cont.value = None
-      else:
-        cont.value = wrapper(val)
-  dummy = container()
-  return property(dummy.fget, dummy.fset)
+    "Define a property always having the specified type"
+    class container():
+        value = None
+        def fget(cont, self):
+            return cont.value
+        def fset(cont, self, val):
+            if val is None:
+                cont.value = None
+            else:
+                cont.value = wrapper(val)
+    dummy = container()
+    return property(dummy.fget, dummy.fset)
 
 class VirtualMachine(object):
-  """
-  Having full information about a virtual machine
-  from the database and the hypervisor.
-  """
-  @classmethod
-  def from_record(cls, record):
-    res = VMSearchQuery(record.uuid).search()
-    return cls(instance=record, attributes=res)
+    """
+    Having full information about a virtual machine
+    from the database and the hypervisor.
+    """
+    @classmethod
+    def from_record(cls, record):
+        res = VMSearchQuery(record.uuid).search()
+        return cls(instance=record, attributes=res)
 
-  id = model_alias('id')
-  user = model_alias('user')
-  name = model_alias('name')
-  uuid = model_alias('uuid')
-  vncport = model_alias('vncport')
-  password = model_alias('password')
+    id = model_alias('id')
+    user = model_alias('user')
+    name = model_alias('name')
+    uuid = model_alias('uuid')
+    vncport = model_alias('vncport')
+    password = model_alias('password')
 
-  # Define attributes' types
-  state = attribute(unicode)
-  cpu = attribute(unicode)
-  os = attribute(unicode)
-  memorysize = attribute(int)
-  disksize = attribute(int)
+    # Define attributes' types
+    state = attribute(unicode)
+    cpu = attribute(unicode)
+    os = attribute(unicode)
+    memorysize = attribute(int)
+    disksize = attribute(int)
 
-  def __init__(self, instance=None, attributes={}):
-    if instance is None:
-      self.instance = VirtualMachineRecord()
-    else:
-      self.instance = instance
-    self.update(attributes)
+    def __init__(self, instance=None, attributes={}):
+        if instance is None:
+            self.instance = VirtualMachineRecord()
+        else:
+            self.instance = instance
+        self.update(attributes)
 
-  def update(self, attributes = {}):
-    for k, v in attributes.items():
-      # Set only decleared attrs.
-      if hasattr(self.__class__, k):
-        setattr(self, k, v)
-    return self
+    def update(self, attributes = {}):
+        for k, v in attributes.items():
+            # Set only decleared attrs.
+            if hasattr(self.__class__, k):
+                setattr(self, k, v)
+        return self
 
-  def to_record(self):
-    return self.instance
+    def to_record(self):
+        return self.instance
 
-  def save(self):
-    if self.is_new():
-      self.uuid = VMCreateOperation(self).submit().get_uuid()
-      self.to_record().save()
-    else:
-      VMUpdateOperation(self).submit()
-      self.to_record().save()
-    return self
+    def save(self):
+        if self.is_new():
+            self.uuid = VMCreateOperation(self).submit().get_uuid()
+            self.to_record().save()
+        else:
+            VMUpdateOperation(self).submit()
+            self.to_record().save()
+        return self
 
-  def is_new(self):
-    return self.uuid is None
+    def is_new(self):
+        return self.uuid is None
 
-  def get_disksize_byte(self):
-    # a unit of disksize is giga byte.
-    return 1024 * 1024 * 1024 * self.disksize
+    def get_disksize_byte(self):
+        # a unit of disksize is giga byte.
+        return 1024 * 1024 * 1024 * self.disksize
 
-  def get_memorysize_kilobyte(self):
-    # a unit of disksize is giga byte.
-    return 1024 * 1024 * self.memorysize
+    def get_memorysize_kilobyte(self):
+        # a unit of disksize is giga byte.
+        return 1024 * 1024 * self.memorysize
 
 class VirtualMachineRecord(models.Model):
-  """ A record class whose instance is saved in the database. """
-  user = models.ForeignKey(User)
-  name = models.CharField(max_length=100, default='your virtual machine')
-  uuid = models.UUIDField(max_length=100)
-  vncport = models.IntegerField()
-  password = models.CharField(max_length=100)
+    """ A record class whose instance is saved in the database. """
+    user = models.ForeignKey(User)
+    name = models.CharField(max_length=100, default='your virtual machine')
+    uuid = models.UUIDField(max_length=100)
+    vncport = models.IntegerField()
+    password = models.CharField(max_length=100)
 
-  @classmethod
-  def find_vnc_port(cls):
-    vm_records = VirtualMachineRecord.objects.all()
-    vncport = 5750
-    for record in vm_records:
-      vncport = max(int(record.vncport), vncport)
-    vncport += 1
-    return vncport
+    @classmethod
+    def find_vnc_port(cls):
+        vm_records = VirtualMachineRecord.objects.all()
+        vncport = 5750
+        for record in vm_records:
+            vncport = max(int(record.vncport), vncport)
+        vncport += 1
+        return vncport
 
-  def __unicode__(self):
-    return self.name
+    def __unicode__(self):
+        return self.name

--- a/vm/tool.py
+++ b/vm/tool.py
@@ -4,16 +4,16 @@ import re
 import random
 
 def GenMac():
-   mac = [ 0x00, 0x16, 0x3e,
-           random.randint(0x00, 0x7f),
-           random.randint(0x00, 0xff),
-           random.randint(0x00, 0xff) ]
-   return ':'.join(map(lambda x: "%02x" % x, mac))
+    mac = [ 0x00, 0x16, 0x3e,
+            random.randint(0x00, 0x7f),
+            random.randint(0x00, 0xff),
+            random.randint(0x00, 0xff) ]
+    return ':'.join(map(lambda x: "%02x" % x, mac))
 
 
 
 def StorageXMLGen(hostname, disksize):
-  return """
+    return """
 <volume type='file'>
   <name>{hostname:s}.img</name>
   <key> /var/lib/libvirt/images/{hostname:s}.img</key>
@@ -31,12 +31,12 @@ def StorageXMLGen(hostname, disksize):
     </permissions>
   </target>
 </volume>""".format(hostname=hostname,
-      disksize=disksize)
+        disksize=disksize)
 
 
 def VMXMLGen(hostname, uuid, memorysize, cpu, image_file, macaddr, websocketport, passwd):
       #<source file='/root/vmimage/{hostname:s}.img'/>
-  return """
+    return """
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>{hostname:s}</name>
   <uuid>{uuid:s}</uuid>
@@ -105,10 +105,10 @@ def VMXMLGen(hostname, uuid, memorysize, cpu, image_file, macaddr, websocketport
     </memballoon>
   </devices>
 </domain>""".format(hostname=hostname,
-      uuid=uuid,
-      memorysize=memorysize,
-      cpu=cpu,
-      image_file=image_file,
-      macaddr=macaddr,
-      websocketport=websocketport, 
-      passwd=passwd)
+        uuid=uuid,
+        memorysize=memorysize,
+        cpu=cpu,
+        image_file=image_file,
+        macaddr=macaddr,
+        websocketport=websocketport,
+        passwd=passwd)

--- a/vm/views.py
+++ b/vm/views.py
@@ -17,26 +17,26 @@ import random
 
 @login_required
 def index(request):
-  vm_records = request.user.virtualmachinerecord_set.all()
-  vms = [VirtualMachine.from_record(vm) for vm in vm_records]
-  # This `cpus` indicates which cpu data should be rendered for each vm.
-  # TODO: Fetch which cpu is used by each vm.
-  cpus = [1]
-  return render(request, 'vm/index.html', {'vms': vms, 'cpus': cpus, 'HYPERVISOR_URL': settings.HYPERVISOR_URL})
+    vm_records = request.user.virtualmachinerecord_set.all()
+    vms = [VirtualMachine.from_record(vm) for vm in vm_records]
+    # This `cpus` indicates which cpu data should be rendered for each vm.
+    # TODO: Fetch which cpu is used by each vm.
+    cpus = [1]
+    return render(request, 'vm/index.html', {'vms': vms, 'cpus': cpus, 'HYPERVISOR_URL': settings.HYPERVISOR_URL})
 
 @login_required
 def create_vm(request):
-  if(request.method == 'POST'):
-    f = CreateVM(request.POST)
-    if (f.is_valid()):
-      # TODO: move these default values to models
-      vncport = VirtualMachineRecord.find_vnc_port()
-      passwd = random_str = ''.join([random.choice(string.ascii_letters + string.digits) for i in range(10)])
-      f.create_instance(request.user, vncport, passwd).save()
-      return HttpResponseRedirect('success')
-  else:
-    f = CreateVM()
-    return render_to_response('vm/create_vm.html', {'form': f}, context_instance=RequestContext(request))
+    if(request.method == 'POST'):
+        f = CreateVM(request.POST)
+        if (f.is_valid()):
+            # TODO: move these default values to models
+            vncport = VirtualMachineRecord.find_vnc_port()
+            passwd = random_str = ''.join([random.choice(string.ascii_letters + string.digits) for i in range(10)])
+            f.create_instance(request.user, vncport, passwd).save()
+            return HttpResponseRedirect('success')
+    else:
+        f = CreateVM()
+        return render_to_response('vm/create_vm.html', {'form': f}, context_instance=RequestContext(request))
 
 @login_required
 def success(request):
@@ -44,16 +44,16 @@ def success(request):
 
 @login_required
 def edit(request, vm_id):
-  vm_record = get_object_or_404(VirtualMachineRecord, pk=vm_id)
-  vm = VirtualMachine.from_record(vm_record)
-  if(request.method == 'POST'):
-    f = UpdateVM(request.POST)
-    if f.is_valid():
-      f.apply_update(vm)
-      vm.save()
-      return HttpResponseRedirect(reverse('vm:index'))
+    vm_record = get_object_or_404(VirtualMachineRecord, pk=vm_id)
+    vm = VirtualMachine.from_record(vm_record)
+    if(request.method == 'POST'):
+        f = UpdateVM(request.POST)
+        if f.is_valid():
+            f.apply_update(vm)
+            vm.save()
+            return HttpResponseRedirect(reverse('vm:index'))
+        else:
+            return render(request, 'vm/edit.html', {'form': f, 'vm': vm})
     else:
-      return render(request, 'vm/edit.html', {'form': f, 'vm': vm})
-  else:
-    f = UpdateVM.from_model(vm)
-    return render(request, 'vm/edit.html', {'form': f, 'vm': vm})
+        f = UpdateVM.from_model(vm)
+        return render(request, 'vm/edit.html', {'form': f, 'vm': vm})

--- a/vm/vmoperation/__init__.py
+++ b/vm/vmoperation/__init__.py
@@ -8,71 +8,71 @@ from .. import tool
 import uuid
 
 class VMOperationBase():
-  @classmethod
-  def get_operator(cls):
-    if not hasattr(cls, 'operator'):
-      cls.operator = VMOperator()
-    return cls.operator
+    @classmethod
+    def get_operator(cls):
+        if not hasattr(cls, 'operator'):
+            cls.operator = VMOperator()
+        return cls.operator
 
 class VMCreateOperation(VMOperationBase):
-  def __init__(self, vm):
-    self.vm = vm
+    def __init__(self, vm):
+        self.vm = vm
 
-  def submit(self):
-    self._define_storage()
-    self._define_vm()
-    self._start()
-    return self
+    def submit(self):
+        self._define_storage()
+        self._define_vm()
+        self._start()
+        return self
 
-  # TODO: move this method to models
-  def get_uuid(self):
-    if not hasattr(self, 'uuid'):
-      self.uuid = uuid.uuid4()
-    return self.uuid
+    # TODO: move this method to models
+    def get_uuid(self):
+        if not hasattr(self, 'uuid'):
+            self.uuid = uuid.uuid4()
+        return self.uuid
 
-  # TODO: move this method to models
-  def get_macaddr(self):
-    if not hasattr(self, 'macaddr'):
-      self.macaddr = tool.GenMac()
-    return self.macaddr
+    # TODO: move this method to models
+    def get_macaddr(self):
+        if not hasattr(self, 'macaddr'):
+            self.macaddr = tool.GenMac()
+        return self.macaddr
 
-  def _define_storage(self):
-    storagexml = tool.StorageXMLGen(self.vm.name, self.vm.get_disksize_byte())
-    print storagexml
-    self.__class__.get_operator().create_storage(storagexml)
+    def _define_storage(self):
+        storagexml = tool.StorageXMLGen(self.vm.name, self.vm.get_disksize_byte())
+        print storagexml
+        self.__class__.get_operator().create_storage(storagexml)
 
-  def _define_vm(self):
-    vmxml = tool.VMXMLGen(
-      hostname = self.vm.name,
-      uuid = self.get_uuid(),
-      memorysize = self.vm.get_memorysize_kilobyte(),
-      cpu = self.vm.cpu,
-      image_file = self.vm.os,
-      macaddr = self.get_macaddr(),
-      websocketport = self.vm.vncport,
-      passwd = self.vm.password)
-    print vmxml
-    self.__class__.get_operator().define_vm(vmxml)
+    def _define_vm(self):
+        vmxml = tool.VMXMLGen(
+          hostname = self.vm.name,
+          uuid = self.get_uuid(),
+          memorysize = self.vm.get_memorysize_kilobyte(),
+          cpu = self.vm.cpu,
+          image_file = self.vm.os,
+          macaddr = self.get_macaddr(),
+          websocketport = self.vm.vncport,
+          passwd = self.vm.password)
+        print vmxml
+        self.__class__.get_operator().define_vm(vmxml)
 
-  def _start(self):
-    self.__class__.get_operator().start_by_hostname(self.vm.name)
+    def _start(self):
+        self.__class__.get_operator().start_by_hostname(self.vm.name)
 
 class VMUpdateOperation(VMOperationBase):
-  def __init__(self, vm):
-    self.vm = vm
+    def __init__(self, vm):
+        self.vm = vm
 
-  def submit(self):
-    # TODO: Implement update operations
-    # Print vm fields temporary
-    print self.vm.cpu
-    print self.vm.memorysize
-    print self.vm.disksize
+    def submit(self):
+        # TODO: Implement update operations
+        # Print vm fields temporary
+        print self.vm.cpu
+        print self.vm.memorysize
+        print self.vm.disksize
 
 class VMSearchQuery(VMOperationBase):
-  def __init__(self, uuid):
-    self.uuid = uuid
+    def __init__(self, uuid):
+        self.uuid = uuid
 
-  def search(self):
-    print type(self.uuid)
-    attrs = self.__class__.get_operator().get_vminfo(self.uuid)
-    return attrs
+    def search(self):
+        print type(self.uuid)
+        attrs = self.__class__.get_operator().get_vminfo(self.uuid)
+        return attrs

--- a/vm/vmoperation/dev.py
+++ b/vm/vmoperation/dev.py
@@ -1,20 +1,20 @@
 
 class VMOperator():
-  def create_vm(self, xml):
-    print 'vm_created: '
-    print xml
+    def create_vm(self, xml):
+        print 'vm_created: '
+        print xml
 
-  def get_vminfo(self, uuid) :
-    return {"name": uuid, "state": 'Stop', 'cpu': 1, "memorysize": 4, 'disksize': 50}
+    def get_vminfo(self, uuid) :
+        return {"name": uuid, "state": 'Stop', 'cpu': 1, "memorysize": 4, 'disksize': 50}
 
-  def create_storage(self, xml):
-    print 'storage_created: '
-    print xml
+    def create_storage(self, xml):
+        print 'storage_created: '
+        print xml
 
-  def define_vm(self, xml):
-    print 'define_vm: '
-    print xml
+    def define_vm(self, xml):
+        print 'define_vm: '
+        print xml
 
-  def start_by_hostname(self, hostname):
-    print 'vm_: '
-    print hostname
+    def start_by_hostname(self, hostname):
+        print 'vm_: '
+        print hostname

--- a/vm/vmoperation/production.py
+++ b/vm/vmoperation/production.py
@@ -15,98 +15,98 @@ from uuid import UUID
 from django.conf import settings
 
 class VMOperator():
-  hypervisor_url = "qemu+tls://" + settings.HYPERVISOR_URL + "/system"
-  def __init__(self):
-    self.con = libvirt.open(self.hypervisor_url)
-    if self.con is None:
-      raise
+    hypervisor_url = "qemu+tls://" + settings.HYPERVISOR_URL + "/system"
+    def __init__(self):
+        self.con = libvirt.open(self.hypervisor_url)
+        if self.con is None:
+            raise
 
-  def start(self, uuid) :
-    os.system("virsh -c {:s} start {:s}".format(self.hypervisor_url, str(uuid)))
+    def start(self, uuid) :
+        os.system("virsh -c {:s} start {:s}".format(self.hypervisor_url, str(uuid)))
 
-  def shutdown(self, uuid) :
-    os.system("virsh -c {:s} shutdown {:s}".format(self.hypervisor_url, str(uuid)))
+    def shutdown(self, uuid) :
+        os.system("virsh -c {:s} shutdown {:s}".format(self.hypervisor_url, str(uuid)))
 
-  def reboot(self, uuid) :
-    os.system("virsh -c {:s} reboot {:s}".format(self.hypervisor_url, str(uuid)))
+    def reboot(self, uuid) :
+        os.system("virsh -c {:s} reboot {:s}".format(self.hypervisor_url, str(uuid)))
 
-  def show_vminfo(self, uuid) :
-    vm = self.con.lookupByUUID(uuid.bytes)
-    if vm is None:
-      raise
-    print"###############"
-    print vm
-    print"###############"
+    def show_vminfo(self, uuid) :
+        vm = self.con.lookupByUUID(uuid.bytes)
+        if vm is None:
+            raise
+        print"###############"
+        print vm
+        print"###############"
 
-    infos = vm.info()
-    print 'UUID = %s' % uuid
-    print 'Name =  %s' % vm.name()
-    print 'State = %s' % infos[0]
-    print 'Max Memory = %d' % infos[1]
-    print 'Number of virt CPUs = %d' % infos[3]
-    print 'CPU Time (in ns) = %d' % infos[2]
-    print ''
+        infos = vm.info()
+        print 'UUID = %s' % uuid
+        print 'Name =  %s' % vm.name()
+        print 'State = %s' % infos[0]
+        print 'Max Memory = %d' % infos[1]
+        print 'Number of virt CPUs = %d' % infos[3]
+        print 'CPU Time (in ns) = %d' % infos[2]
+        print ''
 
 
-  def create_storage(self, xml) :
-    self.con.storagePoolLookupByName("default").createXML(xml)
+    def create_storage(self, xml) :
+        self.con.storagePoolLookupByName("default").createXML(xml)
 
-  def define_vm(self, xml) :
-    self.con.defineXML(xml)
+    def define_vm(self, xml) :
+        self.con.defineXML(xml)
 
-  def start_by_hostname(self, hostname) :
-    self.con.lookupByName(hostname).create()
+    def start_by_hostname(self, hostname) :
+        self.con.lookupByName(hostname).create()
 
-  def destroy_vm(self) :
-    raise
+    def destroy_vm(self) :
+        raise
 
-  def get_vminfo(self, uuid) :
-    print "uuid", uuid
-    vm = self.con.lookupByUUID(uuid.bytes)
-    if vm is None:
-      raise
+    def get_vminfo(self, uuid) :
+        print "uuid", uuid
+        vm = self.con.lookupByUUID(uuid.bytes)
+        if vm is None:
+            raise
 
-    infos = vm.info()
+        infos = vm.info()
 
-    # TODO: Returns disksize also.
-    return {"name":vm.name(), "state": infos[0], "memorysize": infos[1], 'cpu': infos[3]}
+        # TODO: Returns disksize also.
+        return {"name":vm.name(), "state": infos[0], "memorysize": infos[1], 'cpu': infos[3]}
 
-  def get_vmlist(self) :
-    vms_uuid = []
-    ## Obtain running virtual machines
-    running_vms = self.con.listDomainsID()
-    print "runnig_vms"
-    print running_vms
-    for vmid in running_vms:
-      uuid = UUID(bytes=self.con.lookupByID(vmid).UUID())
-      vms_uuid.append(uuid)
-    print "vm_uuid"
-    print vms_uuid
-    ## Obtain defined but not running virtual machines
-    defined_vms = self.con.listDefinedDomains()
-    for vmname in defined_vms:
-      uuid = UUID(bytes=self.con.lookupByName(vmname).UUID())
-      vms_uuid.append(uuid)
-    print "vms_uuid"
-    print vms_uuid
-    return vms_uuid
+    def get_vmlist(self) :
+        vms_uuid = []
+        ## Obtain running virtual machines
+        running_vms = self.con.listDomainsID()
+        print "runnig_vms"
+        print running_vms
+        for vmid in running_vms:
+            uuid = UUID(bytes=self.con.lookupByID(vmid).UUID())
+            vms_uuid.append(uuid)
+        print "vm_uuid"
+        print vms_uuid
+        ## Obtain defined but not running virtual machines
+        defined_vms = self.con.listDefinedDomains()
+        for vmname in defined_vms:
+            uuid = UUID(bytes=self.con.lookupByName(vmname).UUID())
+            vms_uuid.append(uuid)
+        print "vms_uuid"
+        print vms_uuid
+        return vms_uuid
 
-  def get_vm_names_state(self) :
-    vms = []
-    ## Obtain running virtual machines
-    running_vms = self.con.listDomainsID()
-    for vmid in running_vms:
-      uuid = UUID(bytes=self.con.lookupByID(vmid).UUID())
-      vms.append(self.con.lookupByUUID(uuid.bytes))
-    ## Obtain defined but not running virtual machines
-    defined_vms = self.con.listDefinedDomains()
-    for vmname in defined_vms:
-      uuid = UUID(bytes=self.con.lookupByName(vmname).UUID())
-      vms.append(self.con.lookupByUUID(uuid.bytes))
-    return vms
+    def get_vm_names_state(self) :
+        vms = []
+        ## Obtain running virtual machines
+        running_vms = self.con.listDomainsID()
+        for vmid in running_vms:
+            uuid = UUID(bytes=self.con.lookupByID(vmid).UUID())
+            vms.append(self.con.lookupByUUID(uuid.bytes))
+        ## Obtain defined but not running virtual machines
+        defined_vms = self.con.listDefinedDomains()
+        for vmname in defined_vms:
+            uuid = UUID(bytes=self.con.lookupByName(vmname).UUID())
+            vms.append(self.con.lookupByUUID(uuid.bytes))
+        return vms
 
 if __name__ == '__main__':
-  op = VMOperator()
-  for uuid in op.get_vmlist() :
-    op.show_vminfo(uuid)
-    #op.start(uuid)
+    op = VMOperator()
+    for uuid in op.get_vmlist() :
+        op.show_vminfo(uuid)
+        #op.start(uuid)

--- a/vm/vmoperation/vm_network.py
+++ b/vm/vmoperation/vm_network.py
@@ -48,7 +48,7 @@ class VirtualNetwork():
             raise Exception("Not Stopping")
 
     def is_auto(self):
-        if self.virt_nw.autostart() == 1: # 
+        if self.virt_nw.autostart() == 1: #
             return True
         else:
             return False
@@ -76,5 +76,3 @@ if __name__ == '__main__':
     for nw in host_nw.get_list_networks():
         print nw.br_name(), nw.name()
         nw.set_auto(1)
-
-


### PR DESCRIPTION
インデント幅を半角スペース4に統一するために、
Pylintにチェックしてもらうようにしました。
[TravisCI](https://travis-ci.org/tomoasleep/ews)上で各ブランチのインデント幅が半角スペース4に統一されているかチェックが走ります。

また、[EditorConfig](http://editorconfig.org/)の設定も追加しました。
使っているエディタでEditorConfigに対応するプラグインを入れると、ews内でpythonファイルを編集する際に、インデント幅を半角スペース4に設定してくれるようになります。

インデント幅が半角スペース4になっていないものは`reindent-python`を使って直しました。
