### PR TITLE
CPU使用率の更新スクリプトを`python manage.py runscript monitoring`で呼べるようにする

### DIFF
--- a/ews/settings/base.py
+++ b/ews/settings/base.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_extensions',
     'templatetags.filters',
     'accounts',
     'vm',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django >=1.8
+django-extensions >=1.5
 pylint >=1.4

--- a/scripts/monitoring.py
+++ b/scripts/monitoring.py
@@ -1,0 +1,22 @@
+import statistics.stat as s
+import time
+
+def run():
+    stat = s.StatCollector()
+    i = 0
+    while True:
+        try:
+            stat.UpdateVMlist()
+            stat.CollectStat()
+            if i == 0 or i % 6 ==0:
+                s.rrd2plain()
+            if i == 20 or i % 3600 == 0:
+                s.rrd2png()
+            time.sleep(1)
+            if i >= 3600:
+                i = 0
+            i+=1
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            print "Exception ", e

--- a/statistics/stat.py
+++ b/statistics/stat.py
@@ -5,7 +5,7 @@ import rrdtool
 
 hypervisor_url = "qemu+tls://157.82.3.111/system"
 
-statpath = "../static/statistics/data/"
+statpath = "./static/statistics/data/"
 cpurrdpath = statpath + "cpu/"
 cpuusagepath = statpath + "cpuusage/"
 cpupngpath= statpath + "cpupng/"
@@ -139,24 +139,3 @@ class StatCollector():
                     updateCpuRRD(uuid, cpuid, curtime, cpuutil)
                 self.cputimes[cpukey] = vcpus[cpuid]["cputime"]
                 self.lastupdatecpu[cpukey] = curtime
-
-
-if __name__ == "__main__":
-    stat = StatCollector()
-    i = 0
-    while True:
-        try:
-            stat.UpdateVMlist()
-            stat.CollectStat()
-            if i == 0 or i % 6 ==0:
-                rrd2plain()
-            if i == 20 or i % 3600 == 0:
-                rrd2png()
-            time.sleep(1)
-            if i >= 3600:
-                i = 0
-            i+=1
-        except KeyboardInterrupt:
-            break
-        except Exception as e:
-            print "Exception ", e

--- a/statistics/stat.py
+++ b/statistics/stat.py
@@ -2,8 +2,9 @@ import libvirt
 import os
 import time
 import rrdtool
+from django.conf import settings
 
-hypervisor_url = "qemu+tls://157.82.3.111/system"
+hypervisor_url = "qemu+tls://" + settings.HYPERVISOR_URL + "/system"
 
 statpath = "./static/statistics/data/"
 cpurrdpath = statpath + "cpu/"


### PR DESCRIPTION
https://github.com/django-extensions/django-extensions を使って
CPU使用率の更新スクリプトを`python manage.py runscript monitoring`で呼べるようにしました。
django環境下で実行しているので内部からsettingsとかを読むのが楽になります(ハイパーバイザーのurl直打ち等を解消できる)

https://edu.jar.jp/redmine/issues/530
